### PR TITLE
Disable email field while 2fa is processing

### DIFF
--- a/templates/wallet/partials/wallet_2fa.html
+++ b/templates/wallet/partials/wallet_2fa.html
@@ -76,6 +76,7 @@
                         <div class="input-group">
                             <input class="form-control" ng-model="twofactor_state.new_twofac_email"
                                 id="wallet-twofac-email" type="email" name="email" required="required"
+                                ng-disabled="twofactor_state.enabling_email"
                                 placeholder="{{ _('Please enter your email') }}" />
                             <span class="input-group-btn">
                                 <input ng-disabled="!twofactor_state.new_twofac_email || twofactor_state.enabling_email" type="submit" class="btn btn-default" style="margin-top:0; margin-bottom:0;" value="{{ _("Enable") }}"/>


### PR DESCRIPTION
Currently when you first enable 2-factor authentication you can still edit the email field while the call is outstanding. Additionally, if you cancel the operation then the modified value will be shown instead of the one sent to the server, which is a really weird UX experience.