### PR TITLE
Add ability for custom error messages based on error codes and arguments from the server

### DIFF
--- a/static/js/greenwallet/send/controllers.js
+++ b/static/js/greenwallet/send/controllers.js
@@ -535,7 +535,7 @@ angular.module('greenWalletSendControllers',
                     }, function(error) {
                         $rootScope.decrementLoading();
                         that.sending = false;
-                        notices.makeNotice('error', error.args[1]);
+                        notices.makeError($scope, error);
                     });
                 });
             };

--- a/static/js/greenwallet/services.js
+++ b/static/js/greenwallet/services.js
@@ -1882,7 +1882,56 @@ angular.module('greenWalletServices', [])
 }]).factory('notices', ['$rootScope', '$timeout', function($rootScope, $timeout) {
     var notices = $rootScope.notices = [];
     var noticesService = {};
-    noticesService.makeNotice = function(type, msg, timeout) {
+    noticesService.makeError = makeError;
+    noticesService.makeNotice = makeNotice;
+    noticesService.setLoadingText = setLoadingText;
+
+    var errorMessages = {
+        notenoughmoney: gettext("Not enough money, you need ${missing_satoshis} more ${unit} to cover the transaction and fee")
+    };
+
+    return noticesService;
+
+    function makeError ($scope, error) {
+        // this is the error object directly from an API call
+        if (error.error !== 'com.greenaddress.error') {
+            console.warn('Non-greenaddress error passed to makeError');
+            return noticesService.makeNotice('error', error.message || error.msg || error);
+        }
+        var code = getErrorCode(error);
+        var message = error.args[1];
+        var args = parseArgs(error.args[2] || {});
+
+        if (code in errorMessages) {
+            message = errorMessages[code];
+        }
+        message = decorateError(message, args);
+
+        return noticesService.makeNotice('error', message);
+
+        // we want the scope
+        function parseArgs (args) {
+            var div = {'BTC': 1, 'mBTC': 1000, 'µBTC': 1000000, 'bits':1000000};
+            args.unit = $scope.wallet.unit;
+
+            // special parsing rules
+            if (args.missing_satoshis) {
+                args.missing_satoshis = Math.round(args.missing_satoshis * div[$scope.wallet.unit]) / 100000000;
+            }
+            return args;
+        }
+    }
+    function decorateError (message, args) {
+        Object.keys(args).forEach(function (argName) {
+            message = message.replace('${' + argName + '}', args[argName]);
+        });
+        return message;
+    }
+    function getErrorCode (error) {
+        return error.args[0].substr(error.args[0].indexOf('#')+1);
+    }
+
+    function makeNotice (type, msg, timeout) {
         if (msg == null || msg.length == 0)
             return;
 
@@ -1917,13 +1966,13 @@ angular.module('greenWalletServices', [])
                 }
             }, timeout);
         }
-    };
-    noticesService.setLoadingText = function(text, ifNotSet) {
+    }
+    function setLoadingText (text, ifNotSet) {
         if (!ifNotSet || !$rootScope.loading_text) {
             $rootScope.loading_text = text;
         }
-    };
-    return noticesService;
+    }
+
 }]).factory('tx_sender', ['$q', '$rootScope', 'cordovaReady', '$http', 'notices', 'gaEvent', '$location', 'autotimeout', 'device_id', 'btchip',
         function($q, $rootScope, cordovaReady, $http, notices, gaEvent, $location, autotimeout, device_id, btchip) {
     var txSenderService = {};


### PR DESCRIPTION
Currently errors are accepted from the server and either sent directly to the makeNotice method or string matched against the raw message and modified in business logic code and then again send straight to makeNotice

This change adds a makeError method which accepts a raw error object from the server side. It extracts an identifiable error code and checks for a custom error message, inserting data from the server based on a ${parameter_name} syntax.