### PR TITLE
Make PGP Key editing field more friendly

### DIFF
--- a/static/js/greenwallet/settings/controllers.js
+++ b/static/js/greenwallet/settings/controllers.js
@@ -872,9 +872,40 @@ angular.module('greenWalletSettingsControllers',
             $scope.altimeout = $scope.wallet.appearance.altimeout;
         });
     };
-}]).controller('PgpController', ['$scope', 'notices', 'wallets', function PgpController($scope, notices, wallets) {
+}]).controller('PgpModalController', ['$scope', 'notices', 'wallets', '$uibModalInstance', function PgpController($scope, notices, wallets, $modalInstance) {
+    if (!('appearance' in $scope.wallet)) return;
+
+    $scope.pgpstate = {enabled: false, pgp: $scope.wallet.appearance.pgp};
+
+    $scope.savePGP = function() {
+        if ($scope.pgpstate['pgp'] === $scope.wallet.appearance.pgp) return;
+        if (!$scope.pgpstate['enabled']) {
+            $scope.pgpstate['enabled'] = true;
+        }
+        wallets.updateAppearance($scope, 'pgp', $scope.pgpstate['pgp']).then(function() {
+            $scope.pgpstate['enabled'] = false;
+            $scope.wallet.appearance.pgp = $scope.pgpstate['pgp'];
+            $modalInstance.close($scope.pgpstate['pgp']);
+            notices.makeNotice('success', "PGP settings saved");
+        }).catch(function(err) {
+            notices.makeNotice('error', err.args[1]);
+            $scope.pgpstate['enabled'] = false;
+            $scope.pgp = $scope.wallet.appearance.pgp;
+        });
+    };
+}]).controller('PgpController', ['$scope', '$uibModal', function PgpController($scope, $uibModal) {
 
     if (!('appearance' in $scope.wallet)) return;
+
+    $scope.showPGPModal = showPGPModal;
+
+    function showPGPModal () {
+        $uibModal.open({
+            templateUrl: BASE_URL+'/'+LANG+'/wallet/partials/wallet_modal_pgp.html',
+            scope: $scope,
+            controller: 'PgpModalController'
+        });
+    }
 
     $scope.pgpstate = {enabled: false, pgp: $scope.wallet.appearance.pgp};
 

--- a/templates/wallet/partials/wallet_modal_pgp.html
+++ b/templates/wallet/partials/wallet_modal_pgp.html
@@ -35,8 +35,8 @@
                 >{{ _("Change PGP Public Key") }}</button>
             <button class="btn btn-primary" ng-click="submit_me()"
                 ng-disabled="pgpstate.enabled"
-                ng-show="! pgpstate.pgp"
-                >{{ _("Do Not Use PGP") }}</button>
+                ng-show="! pgpstate.pgp && wallet.appearance.pgp "
+                >{{ _("Remove PGP Public Key") }}</button>
         </div>
     </div>
 

--- a/templates/wallet/partials/wallet_modal_pgp.html
+++ b/templates/wallet/partials/wallet_modal_pgp.html
@@ -1,0 +1,43 @@
+<div submittable>
+    <div class="modal-body">
+        <p class="text-center">
+            {{ _("Please enter a valid PGP public key into the box below.") }}
+        </p>
+        <hr>
+        <form ng-submit="savePGP(form.$valid)" name="form" class="form-horizontal">
+            <textarea
+                class="form-control"
+                style="min-width: 100%"
+                rows="18"
+                placeholder="{{ _("----BEGIN PGP PUBLIC KEY...") }}"
+                ng-model="pgpstate.pgp"
+                id="wallet-emailpgp"
+                ng-disabled="pgpstate.enabled"
+                ng-trim="false" >
+            </textarea>
+            <input
+                type="submit"
+                class="hide"
+                submitter />
+        </form>
+    </div>
+
+    <div class="modal-footer">
+        <div class="">
+            <button class="btn btn-danger" ng-click="$dismiss()">{{ _("Cancel") }}</button>
+            <button class="btn btn-primary" ng-click="submit_me()"
+                ng-disabled="pgpstate.enabled"
+                ng-show="pgpstate.pgp && ! wallet.appearance.pgp"
+                >{{ _("Add PGP Public Key") }}</button>
+            <button class="btn btn-primary" ng-click="submit_me()"
+                ng-disabled="pgpstate.enabled"
+                ng-show="pgpstate.pgp && wallet.appearance.pgp && pgpstate.pgp != wallet.appearance.pgp"
+                >{{ _("Change PGP Public Key") }}</button>
+            <button class="btn btn-primary" ng-click="submit_me()"
+                ng-disabled="pgpstate.enabled"
+                ng-show="! pgpstate.pgp"
+                >{{ _("Do Not Use PGP") }}</button>
+        </div>
+    </div>
+
+</div>

--- a/templates/wallet/partials/wallet_settings.html
+++ b/templates/wallet/partials/wallet_settings.html
@@ -326,10 +326,14 @@
   <div class="col-md-9" submittable>
     <form role="form" class="form-horizontal" ng-submit="save_pgp()">
         <label class="col-sm-2 control-label" for="wallet-emailpgp">{{ _("Public Key") }}</label>
-        <div class="input-group">
-            <textarea class="form-control" placeholder="{{ _("----BEGIN PGP PUBLIC KEY...") }}"
-                   ng-model="pgpstate.pgp" id="wallet-emailpgp" ng-trim="false"></textarea>
-            <input type="submit" class="btn btn-primary" ng-show="wallet.appearance.pgp != pgpstate.pgp" value="{{ _("Save") }}" ng-disabled="pgpstate.enabled" />
+        <div class="button-group">
+            <input
+              id="wallet-emailpgp"
+              type="button"
+              class="btn btn-primary"
+              value="{{ _('Change Key') }}"
+              ng-click="showPGPModal()"
+              ng-disabled="pgpstate.enabled" />
         </div>
     </form>
   </div>

--- a/templates/wallet/partials/wallet_settings.html
+++ b/templates/wallet/partials/wallet_settings.html
@@ -323,19 +323,26 @@
     <div class="sub-header">{{ _("PGP") }}</div>
     <div class="sub-header-desc">{{ _("Set your Pretty Good Privacy public key for improved privacy.") }}</div>
   </div>
-  <div class="col-md-9" submittable>
-    <form role="form" class="form-horizontal" ng-submit="save_pgp()">
-        <label class="col-sm-2 control-label" for="wallet-emailpgp">{{ _("Public Key") }}</label>
-        <div class="button-group">
-            <input
-              id="wallet-emailpgp"
-              type="button"
-              class="btn btn-primary"
-              value="{{ _('Change Key') }}"
-              ng-click="showPGPModal()"
-              ng-disabled="pgpstate.enabled" />
-        </div>
-    </form>
+  <div class="col-md-9">
+      <div class="button-group">
+          <input
+            id="wallet-emailpgp"
+            type="button"
+            class="btn btn-primary"
+            value="{{ _('View/Edit Public Key') }}"
+            ng-show="wallet.appearance.pgp"
+            ng-click="showPGPModal()"
+            ng-disabled="pgpstate.enabled" />
+
+          <input
+            id="wallet-emailpgp"
+            type="button"
+            class="btn btn-primary"
+            value="{{ _('Add Public Key') }}"
+            ng-show="! wallet.appearance.pgp"
+            ng-click="showPGPModal()"
+            ng-disabled="pgpstate.enabled" />
+      </div>
   </div>
 </div>
 <hr class="double" ng-show="!settings.noLocalStorage">


### PR DESCRIPTION
Moved the editing gesture into a modal. Added button text for each possible state so that it's very clear what's going on. Made sure error / success messages make sense.


![image](https://cloud.githubusercontent.com/assets/422331/14301818/bfc41d4a-fb4f-11e5-9f1a-8f41af35d470.png)
![image](https://cloud.githubusercontent.com/assets/422331/14301830/d4cd80a0-fb4f-11e5-9020-48e80c730aad.png)

Dirty state with no existing key:
![image](https://cloud.githubusercontent.com/assets/422331/14301825/ccfc95f0-fb4f-11e5-86a3-03bffa459cc5.png)
Dirty state with existing key:
![image](https://cloud.githubusercontent.com/assets/422331/14301842/e22252da-fb4f-11e5-80cd-7c8b066c0277.png)
empty state with existing key:
![image](https://cloud.githubusercontent.com/assets/422331/14301851/ed871d86-fb4f-11e5-95e7-aabaa0bbbd32.png)

Clean state:
![image](https://cloud.githubusercontent.com/assets/422331/14301858/fd2f0f3c-fb4f-11e5-8daf-14fcc76f8882.png)
