### PR TITLE
Fix btc buttons to properly work within ng-repeat

### DIFF
--- a/templates/wallet/partials/wallet_settings.html
+++ b/templates/wallet/partials/wallet_settings.html
@@ -32,7 +32,15 @@
       </div>
       <div class="form-group">
         <div class="btn-group">
-          <button ng-repeat="unit in settings.available_units" type="button" class="btn btn-xs" ng-class="{'btn-primary': settings.unit == unit, 'btn-default': settings.unit != unit}" ng-model="settings.unit" btn-radio="unit" ng-disabled="settings.updating_unit">(( unit ))</button>
+          <button 
+            ng-repeat="unit in settings.available_units"
+            type="button"
+            class="btn btn-xs"
+            ng-class="{'btn-primary': settings.unit == unit, 'btn-default': settings.unit != unit}"
+            ng-click="settings.unit = unit"
+            ng-disabled="settings.updating_unit">
+            (( unit ))
+          </button>
         </div>
       </div>
     </form>


### PR DESCRIPTION
Currently you cannot change your display bitcoin denomination. This fixes that.