### PR TITLE
Update hardware wallet

### DIFF
--- a/static/external/trezor-hid.js
+++ b/static/external/trezor-hid.js
@@ -35466,7 +35466,6 @@ Trezor.prototype.devices = function () {
     return new Promise(function(resolve, reject) {
         self.hid.getDevices(
             {filters:[
-                    {vendorId: 0x2B24, productId: 0x0001},
                     {vendorId: 0x534c, productId: 0x0001}
                 ]},
             function(devices) {

--- a/static/js/greenwallet/wallet/ga-impl/hw-wallets/trezor-hw-wallet.js
+++ b/static/js/greenwallet/wallet/ga-impl/hw-wallets/trezor-hw-wallet.js
@@ -398,12 +398,7 @@ function openDevice (network, options, device) {
   return trezor_api.open(device).then(function (dev_) {
     return dev_.initialize().then(function (init_res) {
       var outdated = false;
-      if (device.vendorId === 11044) {
-        // keepkey
-        if (init_res.message.major_version < 4) {
-          outdated = '4.0.0';
-        }
-      } else {
+      if (device.vendorId === 21324) {
         // satoshilabs
         if ((init_res.message.major_version < 1) ||
             (init_res.message.major_version === 1 &&

--- a/static/js/greenwallet/wallet/ga-impl/hw-wallets/trezor-hw-wallet.js
+++ b/static/js/greenwallet/wallet/ga-impl/hw-wallets/trezor-hw-wallet.js
@@ -402,11 +402,11 @@ function openDevice (network, options, device) {
         // satoshilabs
         if ((init_res.message.major_version < 1) ||
             (init_res.message.major_version === 1 &&
-             init_res.message.minor_version < 5) ||
+             init_res.message.minor_version < 6) ||
             (init_res.message.major_version === 1 &&
-             init_res.message.minor_version === 5 &&
-             init_res.message.patch_version < 2)) {
-          outdated = '1.5.2';
+             init_res.message.minor_version === 6 &&
+             init_res.message.patch_version < 0)) {
+          outdated = '1.6.0';
         }
       }
       if (outdated) {

--- a/static/js/greenwallet/wallet/hw-apis/trezor-hid/trezor.js
+++ b/static/js/greenwallet/wallet/hw-apis/trezor-hid/trezor.js
@@ -38,7 +38,6 @@ Trezor.prototype.devices = function () {
     return new Promise(function(resolve, reject) {
         self.hid.getDevices(
             {filters:[
-                    {vendorId: 0x2B24, productId: 0x0001},
                     {vendorId: 0x534c, productId: 0x0001}
                 ]},
             function(devices) {


### PR DESCRIPTION
- remove support for keepkey
- update min version of trezor to 1.6.0 (note: 1.6.1 is available but not via the Android Trezor manager yet)